### PR TITLE
fix typo in plugin-springcloud.md#12

### DIFF
--- a/docs/en-us/soul/plugin-springcloud.md
+++ b/docs/en-us/soul/plugin-springcloud.md
@@ -6,14 +6,14 @@ description: springcloud plugin
 
 ## Explanation
 
-* This plugin is the core of transforming `http protocol` into `springCloud protocol`.
+* This plugin is the core of transforming `HTTP protocol` into `SpringCloud protocol`.
 
 ## Introducing Plugin Support of SpringCould Gateway
 
 * Introducing those dependencies in the pom.xml file of the gateway. 
 
 ```xml
-  <!--soul springCloud plugin start-->
+  <!--soul SpringCloud plugin start-->
   <dependency>
        <groupId>org.dromara</groupId>
        <artifactId>soul-spring-boot-starter-plugin-springcloud</artifactId>
@@ -25,7 +25,7 @@ description: springcloud plugin
        <artifactId>soul-spring-boot-starter-plugin-httpclient</artifactId>
        <version>${last.version}</version>
    </dependency>
-   <!--soul springCloud plugin end-->
+   <!--soul SpringCloud plugin end-->
 
    <dependency>
         <groupId>org.springframework.cloud</groupId>
@@ -41,7 +41,7 @@ description: springcloud plugin
 
 ## Plugin Setting
 
-* In `soul-admin` --> plugin management-> springCloud ,set to enable. 
+* In `soul-admin` --> plugin management-> SpringCloud ,set to enable. 
 
 * This plugin needs to cooperate with `starter` dependency, please refer to:[user-spring](docs/en-us/soul/user-springcloud.md).
 
@@ -51,5 +51,5 @@ description: springcloud plugin
 
 * Application name: it is your specific application name that needs to be invoked after the conditions are matched.
 
-* Soul will obtain the real IP of the corresponding service and initiate http proxy calls from registration center of springCloud.
-   
+* Soul will obtain the real IP of the corresponding service and initiate http proxy calls from registration center of SpringCloud.
+  

--- a/docs/zh-cn/soul/plugin-springcloud.md
+++ b/docs/zh-cn/soul/plugin-springcloud.md
@@ -6,14 +6,14 @@ description: springcloud插件
 
 ## 说明
 
-* 该插件是用来将`http协议` 转成` springCloud协议` 的核心。
+* 该插件是用来将`HTTP协议` 转成` SpringCloud协议` 的核心。
 
 ## 引入网关 springCloud的插件支持
 
 * 在网关的 pom.xml 文件中引入如下依赖。
 
 ```xml
-  <!--soul springCloud plugin start-->
+  <!--soul SpringCloud plugin start-->
   <dependency>
        <groupId>org.dromara</groupId>
        <artifactId>soul-spring-boot-starter-plugin-springcloud</artifactId>
@@ -25,7 +25,7 @@ description: springcloud插件
        <artifactId>soul-spring-boot-starter-plugin-httpclient</artifactId>
        <version>${last.version}</version>
    </dependency>
-   <!--soul springCloud plugin end-->
+   <!--soul SpringCloud plugin end-->
 
    <dependency>
         <groupId>org.springframework.cloud</groupId>
@@ -41,9 +41,9 @@ description: springcloud插件
 
 ## 插件设置
 
-* 在 `soul-admin` --> 插件管理-> springCloud，设置为开启。
+* 在 `soul-admin` --> 插件管理-> SpringCloud，设置为开启。
 
-* 插件需要配合依赖 `starter` 进行使用，具体请看：[springCloud用户](user-springcloud.md)。
+* 插件需要配合依赖 `starter` 进行使用，具体请看：[SpringCloud用户](user-springcloud.md)。
 
 * 选择器和规则，请详细看：[选择器规则](selector.md)。
 
@@ -51,5 +51,5 @@ description: springcloud插件
 
 * 应用名称：就是你根据条件匹配以后，需要调用的你的具体的应用名称。
 
-* soul会从springCloud的注册中心上面，根据应用名称获取对应的服务真实ip地址，发起http代理调用。
+* soul会从SpringCloud的注册中心上面，根据应用名称获取对应的服务真实ip地址，发起http代理调用。
 


### PR DESCRIPTION
Fix typo in #12 , just modify the plugin-springcloud.md. 
And I think we also need to modify this word(`SpringCloud`) in `soul-admin`  web UI.
It will be more official.